### PR TITLE
Docs: Add PyPI link and version badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+https://pypi.org/project/tgju/
+[![PyPI version](https://img.shields.io/pypi/v/tgju.svg)](https://pypi.org/project/tgju/)
+
 # TGJU Currency Price Fetcher
 
 The `tgju` Python package provides an asynchronous client to fetch live prices of specified currencies and other assets by querying an external API (tgju.org). It is built using `httpx` for non-blocking API calls and `asyncio` for managing asynchronous operations.


### PR DESCRIPTION
Added a direct link to the PyPI project page and a dynamic version badge at the top of the README.md file.

This provides you with quick access to the package's PyPI page and its current version.